### PR TITLE
Fix spacing so json example on /about looks nice

### DIFF
--- a/prefix_finder/frontend/templates/about.html
+++ b/prefix_finder/frontend/templates/about.html
@@ -45,10 +45,10 @@
         <code class="about-page__code">GB-COH-09506232</code>
         <p>Or separating out the list code into it’s own field:</p>
         <p>E.g.</p>
-                <pre><code class="about-page__code">{
-            "scheme": "GB-COH",
-            "id": "09506232
-        }</code></pre>
+        <pre><code class="about-page__code">{
+    "scheme": "GB-COH",
+    "id": "09506232
+}</code></pre>
 
       </div>
       <div class="about-page__half--right">


### PR DESCRIPTION
Currently:
![screen shot 2017-08-09 at 17 55 37](https://user-images.githubusercontent.com/464193/29133643-0fc32638-7d2c-11e7-8200-1348c07ac71e.png)

With fix:
![screen shot 2017-08-09 at 17 56 45](https://user-images.githubusercontent.com/464193/29133667-23dd3d66-7d2c-11e7-81b7-deeb823065dd.png)
