### PR TITLE
Update to include links in the 'to find identifiers' block

### DIFF
--- a/prefix_finder/frontend/templates/list.html
+++ b/prefix_finder/frontend/templates/list.html
@@ -52,7 +52,9 @@
 
           <div class="single-meta-info__instructions">
             <h3>To find identifiers</h3>
+            <p>{%if org_list.access.publicDatabase %}A public database is available for this list at <a href='{{ org_list.access.publicDatabase }}' target="_blank">{{ org_list.access.publicDatabase }}</a>.{% else %}This list is not available online. You may need to contact the organization you plan to identify to ask if they have been given an identifier or registration number by {{ org_list.name.en }} {% endif %}</p>
             <p>{{ org_list.access.guidanceOnLocatingIds|urlize|linebreaks}}</p>
+            {% if org_list.links.opencorporates %}<p>This list can also be searched on <a href='{{ org_list.links.opencorporates }}' target="_blank">OpenCorporates</a>.</p>{% endif %}
           </div>
         </div>
 

--- a/prefix_finder/frontend/templates/list.html
+++ b/prefix_finder/frontend/templates/list.html
@@ -52,7 +52,23 @@
 
           <div class="single-meta-info__instructions">
             <h3>To find identifiers</h3>
-            <p>{%if org_list.access.publicDatabase %}A public database is available for this list at <a href='{{ org_list.access.publicDatabase }}' target="_blank">{{ org_list.access.publicDatabase }}</a>.{% else %}This list is not available online. You may need to contact the organization you plan to identify to ask if they have been given an identifier or registration number by {{ org_list.name.en }} {% endif %}</p>
+            {%if org_list.access.publicDatabase or org_list.access.onlineAccessDetails %}
+              {%if org_list.access.publicDatabase %}
+                <p>
+                  A public database is available for this list at <a href='{{ org_list.access.publicDatabase }}' target="_blank">{{ org_list.access.publicDatabase }}</a>.
+                </p>
+              {% endif %}
+              {%if org_list.access.onlineAccessDetails %}  
+                <p>
+                  {{ org_list.access.onlineAccessDetails }}
+                </p>
+              {% endif %}
+            {% else %}
+              <p>
+                This list is not available online. You may need to contact the organization you plan to identify to ask if they have been given an identifier or registration number by {{ org_list.name.en }}.
+              </p> 
+            {% endif %}
+
             <p>{{ org_list.access.guidanceOnLocatingIds|urlize|linebreaks}}</p>
             {% if org_list.links.opencorporates %}<p>This list can also be searched on <a href='{{ org_list.links.opencorporates }}' target="_blank">OpenCorporates</a>.</p>{% endif %}
           </div>


### PR DESCRIPTION
Based on #152.

@Bjwebb If this passes tests, I think it would be good to do a quick deploy of - as I hadn't spotted quite how hidden the links to lists were before. 