### PR TITLE
fallback link where no id guidance & country code abbreviations

### DIFF
--- a/prefix_finder/frontend/static/css/main.css
+++ b/prefix_finder/frontend/static/css/main.css
@@ -1137,7 +1137,7 @@ fieldset {
   display: flex;
   flex-direction: column;
 }
-@media (min-width: 40em) {
+@media (min-width: 100em) {
   .homepage {
     height: 100vh;
   }

--- a/prefix_finder/frontend/templates/base.html
+++ b/prefix_finder/frontend/templates/base.html
@@ -27,7 +27,7 @@
         <p class="ribbon-alert"><i class="material-icons">error_outline</i> You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->
     {% if branch and branch != "master" %}
-      <p class="ribbon-alert"><i class="material-icons">error_outline</i> You are currently previewing branch {{ branch }}. <a href="/_preview_branch/master">Return to master</a> or <a href="https://github.com/OpenDataServices/org-ids/compare/{{ branch }}">view on GitHub</a></p>
+      <p class="ribbon-alert"><i class="material-icons">error_outline</i> You are currently previewing branch {{ branch }}. <a href="/_preview_branch/master">Return to master</a> or <a href="https://github.com/org-id/register/compare/{{ branch }}">view on GitHub</a></p>
     {% endif %}
 
     {% block main %}{% endblock %}

--- a/prefix_finder/frontend/templates/list.html
+++ b/prefix_finder/frontend/templates/list.html
@@ -20,7 +20,7 @@
           </div>
 
         <div class="single-sidebar__block single-sidebar--dark">
-          <p>The code for this list is <br/><code>{{ org_list.code }}</code>. When you can located the organization you wish to identify in this list, you should either:</p>
+          <p>The code for this list is <br/><code>{{ org_list.code }}</code>. When you have located the organization you wish to identify in this list, you should either:</p>
           <p>Enter it in an identifier database field prefixed with <code>{{ org_list.code }}</code>.</p>
           <h2>Example</h2>
           <pre>
@@ -40,7 +40,7 @@
         <div class="single-content__block single-meta-info">
           <ul class="single-meta-info__categories single-categories">
             <li class="single-categories__item single-categories--coverage">
-              <p>Coverage: {% for x in org_list.coverage %}<span>{{ x }}{% if not forloop.last %},{% endif %} </span>{% endfor %}</p>
+              <p>Coverage: {% for x in org_list.coverage %}<span><abbr title="{% for key, value in lookups %}{% if key == x %}{{ value }}{% endif %}{% endfor %}">{{ x }}</abbr>{% if not forloop.last %},{% endif %} </span>{% endfor %}</p>
             </li>
 
             {% if org_list.sector %}

--- a/prefix_finder/frontend/templates/list.html
+++ b/prefix_finder/frontend/templates/list.html
@@ -52,7 +52,11 @@
 
           <div class="single-meta-info__instructions">
             <h3>To find identifiers</h3>
-            <p>{{ org_list.access.guidanceOnLocatingIds|urlize|linebreaks}}</p>
+            {% if org_list.access.guidanceOnLocatingIds %}
+              <p>{{ org_list.access.guidanceOnLocatingIds|urlize|linebreaks}}</p>
+            {% else %}
+              <p><a href="{{ org_list.url }}" target="_blank">Visit the website.</a></p>
+            {% endif %}
           </div>
         </div>
 

--- a/prefix_finder/frontend/templates/list.html
+++ b/prefix_finder/frontend/templates/list.html
@@ -40,7 +40,7 @@
         <div class="single-content__block single-meta-info">
           <ul class="single-meta-info__categories single-categories">
             <li class="single-categories__item single-categories--coverage">
-              <p>Coverage: {% for x in org_list.coverage %}<span><abbr title="{% for key, value in lookups %}{% if key == x %}{{ value }}{% endif %}{% endfor %}">{{ x }}</abbr>{% if not forloop.last %},{% endif %} </span>{% endfor %}</p>
+              <p>Coverage: {% for x in org_list.coverage %}<span><abbr title="{% for key, value in lookups.coverage %}{% if key == x %}{{ value }}{% endif %}{% endfor %}">{{ x }}</abbr>{% if not forloop.last %},{% endif %} </span>{% endfor %}</p>
             </li>
 
             {% if org_list.sector %}

--- a/prefix_finder/frontend/views.py
+++ b/prefix_finder/frontend/views.py
@@ -500,7 +500,7 @@ def list_details(request, prefix):
 
     except KeyError:
         raise Http404('Organization list {} does not exist'.format(prefix))
-    return render(request, 'list.html', context={'org_list': org_list, 'branch':use_branch})
+    return render(request, 'list.html', context={'org_list': org_list, 'lookups': lookups, 'branch':use_branch})
 
 
 def _get_filename(use_branch='master'):


### PR DESCRIPTION
It took me a few visits to notice the link to publisher website at the top right of title.

For lists that don't have as much information, it might be better to provide the user a link to the website where they expect to find something e.g. under 'Find identifiers'. So if there is no guidance (`access.guidanceOnLocatingIds`) just present a link to the `url` (instead of 'None')

![image](https://user-images.githubusercontent.com/10833378/29462535-9c285b96-8427-11e7-9f8b-477c6c7444c4.png)
