### PR TITLE
show onlineAccessDetails under "To find identifiers"

### DIFF
--- a/prefix_finder/frontend/templates/list.html
+++ b/prefix_finder/frontend/templates/list.html
@@ -51,10 +51,11 @@
           </ul>
 
           <div class="single-meta-info__instructions">
-            <h3>To find identifiers</h3>
+            <h3>Search options</h3>
             {% if org_list.access.onlineAccessDetails %}
               <p>{{ org_list.access.onlineAccessDetails|urlize|linebreaks }}</p>
             {% endif %}
+            <h3>Find and use identifiers</h3>
             {% if org_list.access.guidanceOnLocatingIds %}
               <p>{{ org_list.access.guidanceOnLocatingIds|urlize|linebreaks }}</p>
             {% endif %}

--- a/prefix_finder/frontend/templates/list.html
+++ b/prefix_finder/frontend/templates/list.html
@@ -52,7 +52,12 @@
 
           <div class="single-meta-info__instructions">
             <h3>To find identifiers</h3>
-            <p>{{ org_list.access.guidanceOnLocatingIds|urlize|linebreaks}}</p>
+            {% if org_list.access.onlineAccessDetails %}
+              <p>{{ org_list.access.onlineAccessDetails|urlize|linebreaks }}</p>
+            {% endif %}
+            {% if org_list.access.guidanceOnLocatingIds %}
+              <p>{{ org_list.access.guidanceOnLocatingIds|urlize|linebreaks }}</p>
+            {% endif %}
           </div>
         </div>
 


### PR DESCRIPTION
Re #173 and https://github.com/org-id/register/issues/66, this provides a solutions to lists which appear in multiple locations, perhaps with multiple urls, and therefore have a more detailed explanation in `onlineAccessDetails` of how to find identifiers.