### PR TITLE
better link/more info icons plus tooltip titles

### DIFF
--- a/prefix_finder/frontend/templates/list.html
+++ b/prefix_finder/frontend/templates/list.html
@@ -7,7 +7,7 @@
 
     <div class="main-content single-content">
       <header class="single-content__header">
-        <a href="{{ org_list.url }}" class="button" target="_blank"><i class="material-icons">link</i></a>
+        <a href="{{ org_list.url }}" class="button" target="_blank"><i class="material-icons" title="Visit website for this list">launch</i></a>
         <h1>{{ org_list.name.en }} <span>({{ org_list.code }})</span></h1>
       </header>
 

--- a/prefix_finder/frontend/templates/results.html
+++ b/prefix_finder/frontend/templates/results.html
@@ -115,7 +115,7 @@
                 </div>
 
                 <footer class="card__controls">
-                  <a href="{{ result.url }}" class="button" target="_blank"><i class="material-icons">launch</i></a>
+                  <a href="{{ result.url }}" class="button" target="_blank"><i class="material-icons" title="Visit the website for this list">launch</i></a>
                   <div class="card__list-code"><p>List Code <code>{{ result.code }}</code></p></div>
                   <a href="{% url "list" result.code %}" class="button"><i class="material-icons" title="More information about this list">info_outline</i></a>
                 </footer>
@@ -174,7 +174,7 @@
                 </div>
 
                 <footer class="card__controls">
-                  <a href="{{ result.url }}" class="button" target="_blank"><i class="material-icons">launch</i></a>
+                  <a href="{{ result.url }}" class="button" target="_blank"><i class="material-icons" title="Visit the website for this list">launch</i></a>
                   <div class="card__list-code"><p>List Code <code>{{ result.code }}</code></p></div>
                   <a href="{% url "list" result.code %}" class="button"><i class="material-icons" title="More information about this list">info_outline</i></a>
                 </footer>

--- a/prefix_finder/frontend/templates/results.html
+++ b/prefix_finder/frontend/templates/results.html
@@ -56,9 +56,9 @@
                 </div>
 
                 <footer class="card__controls">
-                  <a href="{{ result.url }}" class="button" target="_blank"><i class="material-icons">link</i></a>
+                  <a href="{{ result.url }}" class="button" target="_blank"><i class="material-icons" title="Visit the website for this list">launch</i></a>
                   <div class="card__list-code"><p>List Code <code>{{ result.code }}</code></p></div>
-                  <a href="{% url "list" result.code %}" class="button"><i class="material-icons">zoom_out_map</i></a>
+                  <a href="{% url "list" result.code %}" class="button"><i class="material-icons" title="More information about this list">info_outline</i></a>
                 </footer>
               </article>
             </div>
@@ -115,9 +115,9 @@
                 </div>
 
                 <footer class="card__controls">
-                  <a href="{{ result.url }}" class="button" target="_blank"><i class="material-icons">link</i></a>
+                  <a href="{{ result.url }}" class="button" target="_blank"><i class="material-icons">launch</i></a>
                   <div class="card__list-code"><p>List Code <code>{{ result.code }}</code></p></div>
-                  <a href="{% url "list" result.code %}" class="button"><i class="material-icons">zoom_out_map</i></a>
+                  <a href="{% url "list" result.code %}" class="button"><i class="material-icons" title="More information about this list">info_outline</i></a>
                 </footer>
               </article>
             </div>
@@ -174,9 +174,9 @@
                 </div>
 
                 <footer class="card__controls">
-                  <a href="{{ result.url }}" class="button" target="_blank"><i class="material-icons">link</i></a>
+                  <a href="{{ result.url }}" class="button" target="_blank"><i class="material-icons">launch</i></a>
                   <div class="card__list-code"><p>List Code <code>{{ result.code }}</code></p></div>
-                  <a href="{% url "list" result.code %}" class="button"><i class="material-icons">zoom_out_map</i></a>
+                  <a href="{% url "list" result.code %}" class="button"><i class="material-icons" title="More information about this list">info_outline</i></a>
                 </footer>
               </article>
             </div>


### PR DESCRIPTION
Changes the icon for going to the full list page (currently a map-zoom-out icon) and the external link to look like something a bit more related to its action. Refs #147. Also puts in cursor titles so you know what you're going to get before the click.

![image](https://user-images.githubusercontent.com/10833378/32391574-7cf44660-c0ca-11e7-8227-5e7d5207823c.png)
