### PR TITLE
Signpost handbook from site

### DIFF
--- a/prefix_finder/frontend/templates/footer.html
+++ b/prefix_finder/frontend/templates/footer.html
@@ -6,6 +6,7 @@
     {% trans "The code for this site is available on Github" %}: <a href="https://github.com/OpenDataServices/org-ids/">{%trans "org-ids" %}</a>.
     {% trans "Licence" %}: <a href="https://www.gnu.org/licenses/agpl-3.0.html">{% trans "AGPLv3" %}</a>.
     {% trans "Report/View issues" %}: <a href="https://github.com/OpenDataServices/org-ids/issues">{% trans "org-id issues" %}</a>.
+    {% trans "To contribute lists" %}: <a href="http://docs.org-id.guide/en/latest">{% trans "contributors handbook" %}</a>.
     <a href="{% url 'terms' %}">{% trans "Terms &amp; Conditions" %}</a>.
     {% blocktrans %}Running version {% endblocktrans %}<a href="https://github.com/OpenDataServices/org-ids/tree/{{ request.tag }}">{{ request.tag }}</a>.
   </p>

--- a/prefix_finder/frontend/templates/list.html
+++ b/prefix_finder/frontend/templates/list.html
@@ -58,6 +58,7 @@
 
         <div class="single-content__block single-suggest">
           <p>You can suggest an edit to our information about this list by <a href="https://github.com/org-id/register/issues/new">posting an issue</a> or <a href="https://github.com/org-id/register">submitting a pull request</a>.</p>
+          <p>The <a href="http://docs.org-id.guide/en/latest/contribute/#proposing-a-correction-or-update" target="_blank">contributors handbook</a> details how to propose changes to an existing list, and how you can request or propose a new list.</p>
         </div>
       </div>
     </div>

--- a/prefix_finder/frontend/templates/results.html
+++ b/prefix_finder/frontend/templates/results.html
@@ -71,8 +71,10 @@
           <h1>Possible Lists</h1>
           {% if all_results.recommended %}
             <p>It's possible you will find the organization(s) you are looking for in one of the lists below…</p>
-          {% else %}
+          {% elif all_result.suggested %}
             <p>No alternative results.</p>
+          {% else %}
+            <p>No alternative results. Think there should be a list here? You can make a request, read the <a href="http://docs.org-id.guide/en/latest/contribute/" target="_blank">contributors handbook</a> for details on how to request or propose a new list.</p>
           {% endif %}
         </header>
 


### PR DESCRIPTION
https://twitter.com/andylolz/status/923117562426286081 from @andylolz (cc @timgdavies)

Better linking to the [contributors handbook](http://docs.org-id.guide/en/latest/) from the site is a good idea. Currently only linked to from the About page (amidst lots of other text)

This links it from:

- the footer, along with all the other links there
- the results page IF there's no suggested or possible list results returned (block suggests that the user might want to request or propose a list). We could broaden that and have it with every results regardless of return.
- a list's page, underneath where the user is prompted to consider proposing changes, so that they do so more informed