### PR TITLE
Show preview banner on /results (when previewing a non-`master` branch)

### DIFF
--- a/prefix_finder/frontend/static/css/main.css
+++ b/prefix_finder/frontend/static/css/main.css
@@ -148,7 +148,7 @@ code {
 
 .sidebar {
   width: 300px;
-  position: fixed;
+  position: absolute;
   left: 0;
   top: 0;
   bottom: 0;

--- a/prefix_finder/frontend/views.py
+++ b/prefix_finder/frontend/views.py
@@ -475,7 +475,7 @@ def home(request):
 
 
 def results(request):
-    branch = request.session.get('branch', 'master')
+    use_branch = request.session.get('branch', 'master')
     query = {key: value for key, value in request.GET.items() if value and value != 'all'}
     context = {
         'lookups': {
@@ -489,7 +489,10 @@ def results(request):
     if query:
         context['lookups'] = get_lookups(query, branch)
 
+    context['branch'] = use_branch
+
     return render(request, 'results.html', context=context)
+
 
 def list_details(request, prefix):
     use_branch = request.session.get('branch', 'master')


### PR DESCRIPTION
Refs #183.

This doesn’t solve #183, because:
 * it’s only /results – not /about or /terms
 * ~~it looks a bit ugly because of the `fixed` position sidebar (I wonder if `absolute` positioning would be better?)~~ UPDATE: I added a commit to absolutely position the sidebar, which makes the banner look roughly correct. I don’t thiiiink this breaks old browsers… but it might.