### PR TITLE
Use the Example Identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Steps to installation:
 * Create a virtual environment (note this application uses python3)
 * Activate the virtual environment
 * Install dependencies
+* Apply migrations
 * Run the development server
 
 ```
@@ -63,6 +64,7 @@ cd org-ids
 virtualenv .ve --python=/usr/bin/python3
 source .ve/bin/activate
 pip install -r requirements_dev.txt
+python manage.py migrate
 python manage.py runserver
 ```
 

--- a/prefix_finder/frontend/templates/list.html
+++ b/prefix_finder/frontend/templates/list.html
@@ -20,13 +20,25 @@
           </div>
 
         <div class="single-sidebar__block single-sidebar--dark">
+          <h2>How to use</h2>
           <p>The code for this list is <br/><code>{{ org_list.code }}</code>. When you have located the organization you wish to identify in this list, you should either:</p>
           <p>Enter it in an identifier database field prefixed with <code>{{ org_list.code }}</code>.</p>
-          <h2>Example</h2>
           <pre>
 <code>{{ org_list.code }}-[ IDENTIFIER ]</code>
           </pre>
-          <p>Or, use it within a two-part identifier, with <code>{{ org_list.code }}</code> as the 'scheme', and the identifier you have located as the 'identifier' field. </p>
+          {% if org_list.access.exampleIdentifiers|length >= 1 %}
+          {% if org_list.access.exampleIdentifiers|length = 1 %}
+            <h2>Example</h2>
+          {% else %}
+            <h2>Examples</h2>
+          {% endif %}
+          <pre>
+              {% for x in org_list.access.exampleIdentifiers|slice:":3" %}
+<code>{{ org_list.code }}-{{ x }}</code>
+              {% endfor %}
+          </pre>
+          {% endif %}
+          <p>Alternatively, use it within a two-part identifier, with <code>{{ org_list.code }}</code> as the 'scheme', and the identifier you have located as the 'identifier' field. </p>
         </div>
       </div>
 


### PR DESCRIPTION
We ask contributors to submit 3-5 example identifiers to the list (sometimes many more are present)

These aren't used in the interface at present. This adds them to the sidebar (where the generic "example" is) so that users can get a good idea of what their org-ids should look like.

The loop is limited to at most 3 examples.