### PR TITLE
If there’s just one example, make heading singular

### DIFF
--- a/prefix_finder/frontend/templates/list.html
+++ b/prefix_finder/frontend/templates/list.html
@@ -29,7 +29,7 @@
 <code>{{ org_list.code }}-[ IDENTIFIER ]</code>
           </pre>
           {% if org_list.access.exampleIdentifiers|length >= 1 %}
-          {% if org_list.access.exampleIdentifiers|length = 1 %}
+          {% if org_list.access.exampleIdentifiers|length == 1 %}
             <h2>Example</h2>
           {% else %}
             <h2>Examples</h2>


### PR DESCRIPTION
Equality testing should be done with a double equals.

Fixes #198.